### PR TITLE
Leave out parentheses with sql/build

### DIFF
--- a/src/clj_pg/honey.clj
+++ b/src/clj_pg/honey.clj
@@ -100,7 +100,7 @@
   (str (sqlf/to-sql col) " not ilike " (sqlf/to-sql qstr)))
 
 (defn- honetize [hsql]
-  (cond (map? hsql) (sql/format hsql :quoting :ansi)
+  (cond (map? hsql) (sql/format (sql/build hsql) :quoting :ansi)
         (vector? hsql) (if (keyword? (first hsql)) (sql/format (apply sql/build hsql) :quoting :ansi) hsql)
         (string? hsql) [hsql]))
 


### PR DESCRIPTION
When you batch several requests in a vector, you use the extended semantics of sql/build. For example, it accepts this kind of query:

```
{:select :* :from :user}
```

It would be useful to be able to do this with single requests too.